### PR TITLE
Resolve compilation errors on pi3 b+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,9 @@
-keybusdev-overlay.dtb
+keybusdev-overlay.dtb*
+*.mod.*
+*.cmd
+.tmp_versions
+*.symvers
+*.o
+*.ko
+*.order
+

--- a/README.md
+++ b/README.md
@@ -10,8 +10,11 @@ on Linux.
 * exposes a kernel object under /sys/keybus for reading the latest state of the
   alarm system and statistics
 
-Tested on Raspberry Pi B (Rev 2.1 UK) using `Linux raspberrypi 4.1.13+ #826 PREEMPT
+Tested on:
+- Raspberry Pi B (Rev 2.1 UK) using `Linux raspberrypi 4.1.13+ #826 PREEMPT 
 Fri Nov 13 20:13:22 GMT 2015 armv6l GNU/Linux`.
+- Raspberry Pi 3 Model B Rev 1.2 (Pi 3 B+) using `Linux retropie 4.14.98-v7+ #1200 SMP 
+Tue Feb 12 20:27:48 GMT 2019 armv7l GNU/Linux`.
 
 ## Installation
 
@@ -38,6 +41,20 @@ To use the provided `dts` file, compile it, install it to your overlays director
 ```
 dtc -I dts -O dtb -o keybusdev-overlay.dtb keybusdev-overlay.dts
 cp keybusdev-overlay.dtb /boot/overlays
+shutdown -r now
+```
+
+**For configuring the Device Tree file on Raspberry Pi 3 B+.**
+
+```
+dtc -I dts -O dtb -o keybusdev-overlay.dtbo keybusdev-overlay.dts
+cp keybusdev-overlay.dtbo /boot/overlays
+```
+
+
+Edit the `/boot/config.txt` file and add/modify `dtoverlay=` line as follows: `dtoverlay=keybusdev-overlay`
+
+```
 shutdown -r now
 ```
 

--- a/keybus-dev.c
+++ b/keybus-dev.c
@@ -20,7 +20,7 @@
 #include <linux/circ_buf.h>
 #include <linux/wait.h>
 #include <linux/sched.h>
-#include <asm/uaccess.h>
+#include <linux/uaccess.h>
 #include <asm/bitops.h>
 #include <linux/platform_data/bcm2708.h>
 

--- a/keybus-protocol.c
+++ b/keybus-protocol.c
@@ -1,6 +1,6 @@
 #include <linux/kernel.h>
 #include "keybus-protocol.h"
-
+#include <linux/string.h>
 
 // Developed against Power832 from circa year 2000
 
@@ -192,17 +192,17 @@ static int parse_A5(char *packet, char *buffer) {
 		sprintf(extra, " disarmed by %02d (%s)", userId, 
 			userId >= 40 ? "master" : "user");
 	    } else if (action == 0xe7) {
-		extra = " error (possibly battery)";
+		strcpy(extra, " error (possibly battery)");
 	    } else if (action == 0xef) {
-		extra = " error resolved";
+		strcpy(extra, " error resolved");
 	    }
 	} else if (flag == 2) {
 	    if (action == 0x68) {
-		extra = " PGM2 (*72)";
+		strcpy(extra, " PGM2 (*72)");
 	    } else if (action == 0x98) {
-		extra = " armed (stay)";
+		strcpy(extra, " armed (stay)");
 	    } else if (action == 0x99) {
-		extra = " armed (away)";
+		strcpy(extra, " armed (away)");
 	    }
 	}
     }

--- a/keybusdev-overlay.dts
+++ b/keybusdev-overlay.dts
@@ -2,7 +2,7 @@
 /plugin/;
 
 / {
-    compatible = "brcm,bcm2708";
+    compatible = "brcm,bcm2708,bcm2710,bcm2835";
 
     fragment@0 {
         target = <&gpio>;


### PR DESCRIPTION
Hope this receives you well.

This commit resolves the compilation errors I received on the Raspberry Pi 3 B+.  It resolves #2 

I am working on fully testing as working on the hardware interface at the moment but thought this might help.

This may cause breaking changes for the pi 2 version you have previously tested with.